### PR TITLE
Support mocha reporters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@
 $ npm install mocha-cloud
 ```
 
-  Add `./client.js` to your test scripts, and pass `mocha.run()`
+  Add [client.js](http://component.jit.su/visionmedia/mocha-cloud/download/latest.js) to your test scripts, and call `mochaCloud(mocha).run()`
   to the function, allowing it to listen on `mocha.Runner` events.
 
   Alternatively if you use [component](https://github.com/component/component)
@@ -26,23 +26,20 @@ $ component install visionmedia/mocha-cloud
 ## Example
 
 ```js
-
+var reporters = require('mocha').reporters;
 var Cloud = require('mocha-cloud');
+
 var cloud = new Cloud('your project name', 'username', 'access key');
-cloud.browser('iphone', '5.0', 'Mac 10.6');
 cloud.browser('ipad', '6', 'Mac 10.8');
 cloud.url('http://localhost:3000/test/');
 
-cloud.on('init', function(browser){
+cloud.on('init', function(browser, runner){
   console.log('  init : %s %s', browser.browserName, browser.version);
+  new reporters['Spec'](runner);
 });
 
 cloud.on('start', function(browser){
   console.log('  start : %s %s', browser.browserName, browser.version);
-});
-
-cloud.on('end', function(browser, res){
-  console.log('  end : %s %s : %d failures', browser.browserName, browser.version, res.failures);
 });
 
 cloud.start();

--- a/client.js
+++ b/client.js
@@ -1,31 +1,36 @@
+var jssn = require('jssn');
 
 /**
  * Listen to `runner` events to populate a global
- * `.mochaResults` var which may be used by selenium
+ * `.stream()` function which may be used by selenium
  * to report on results.
  *
- *    cloud(mocha.run());
+ *    cloud(mocha).run();
  *
- * @param {Runner} runner
+ * @param {Mocha} mocha
  * @api public
  */
 
-module.exports = function(runner){
-  var failed = [];
+module.exports = function mochaCloud(mocha) {
+  var Mocha = mocha.constructor;
+  
+  var events = [];
+  window.stream = function () {
+    var e = jssn.stringify(events);
+    events = [];
+    return e;
+  };
 
-  runner.on('fail', function(test, err){
-    failed.push({
-      title: test.title,
-      fullTitle: test.fullTitle(),
-      error: {
-        message: err.message,
-        stack: err.stack
-      }
-    });
-  });
+  var HTML = Mocha.reporters.HTML;
+  function SauceLabs(runner, root) {
+    var emit = runner.emit;
+    runner.emit = function () {
+      emit.apply(this, arguments);
+      events.push(arguments)
+    };
+    HTML.call(this, runner, root);
+  }
+  SauceLabs.prototype = HTML.prototype;
 
-  runner.on('end', function(){
-    runner.stats.failed = failed;
-    global.mochaResults = runner.stats;
-  });
-};
+  return mocha.reporter(SauceLabs);
+}

--- a/client.js
+++ b/client.js
@@ -20,6 +20,22 @@ module.exports = function mochaCloud(mocha) {
     events = [];
     return e;
   };
+  
+  window.console = window.console || {};
+  var methods = ['dir', 'error', 'group', 'gropCollapsed', 'groupEnd', 'info', 'log', 'time', 'timeEnd', 'trace', 'warn'];
+  for (var i = 0; i < methods.length; i++) {
+    (function (method) {
+      var old = console[method] || function () {};
+      console[method] = function () {
+        if (typeof old === 'function') old.apply(this, arguments);
+        var args = ['console-' + method];
+        for (var i = 0; i < arguments.length; i++) {
+          args.push(arguments[i]);
+        }
+        events.push(args);
+      };
+    }(methods[i]));
+  }
 
   var HTML = Mocha.reporters.HTML;
   function SauceLabs(runner, root) {

--- a/component.json
+++ b/component.json
@@ -5,5 +5,6 @@
   "keywords": ["mocha", "test", "tdd", "bdd", "cloud", "selenium"],
   "scripts": ["client.js"],
   "main": "client.js",
+  "dependencies": {"ForbesLindesay/jssn": "*"},
   "license": "MIT"
 }

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ Cloud.prototype.start = function(fn){
               if (err) return done(err);
 
               var ended = false;
+              runner.emit('raw jssn', res);
               var log = jssn.parse(res, mocha);
 
               for (var i = 0; i < log.length; i++) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@
 var Emitter = require('events').EventEmitter
   , debug = require('debug')('mocha-cloud')
   , Batch = require('batch')
-  , wd = require('wd');
+  , wd = require('wd')
+  , mocha = require('mocha')
+  , jssn = require('jssn');
 
 /**
  * Expose `Cloud`.
@@ -108,31 +110,43 @@ Cloud.prototype.start = function(fn){
     conf.name = self.name;
 
     batch.push(function(done){
+      var runner = new Emitter();
       debug('running %s %s %s', conf.browserName, conf.version, conf.platform);
       var browser = wd.remote('ondemand.saucelabs.com', 80, self.user, self.key);
-      self.emit('init', conf);
+      self.emit('init', conf, runner);
+      runner.on('end', function () {
+        self.emit('end', conf, runner);
+      });
 
       browser.init(conf, function(){
         debug('open %s', self._url);
-        self.emit('start', conf);
+        self.emit('start', conf, runner);
 
         browser.get(self._url, function(err){
           if (err) return done(err);
 
           function wait() {
-            browser.eval('window.mochaResults', function(err, res){
+            browser.eval('window.stream()', function(err, res){
               if (err) return done(err);
 
-              if (!res) {
-                debug('waiting for results');
-                setTimeout(wait, 1000);
-                return;
+              var ended = false;
+              var log = jssn.parse(res, mocha);
+
+              for (var i = 0; i < log.length; i++) {
+                debug('Event %s: %j', log[i][0], log[i]);
+                if (log[i][0] === 'end') ended = true;
+                runner.emit.apply(runner, log[i]);
               }
 
-              debug('results %j', res);
-              self.emit('end', conf, res);
-              browser.quit();
-              done(null, res);
+              if (!ended) {
+                debug('still running');
+                setTimeout(wait, 1000);
+              } else {
+                debug('tests completed');
+                self.emit('end', conf, res);
+                browser.quit();
+                done(null, res);
+              }
             });
           }
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "dependencies": {
     "wd": "0.0.26",
     "debug": "~0.7.0",
-    "batch": "~0.2.1"
+    "batch": "~0.2.1",
+    "mocha": "*",
+    "jssn": "*"
   },
   "devDependencies": {
-    "mocha": "*",
     "should": "*"
   },
   "main": "index"


### PR DESCRIPTION
This pull request changes the API significantly.  Instead of handling events on the client and saving info into mochaResults, we serialize all the event information and send it to the reporter as JSON.  By using `jssn` it can send circular references fine and also re-construct the prototype chains properly on arrival.

The upshot of the API change is that you can use any of the standard mocha reporters.  Here is a demo of browser side tests running with the `spec` reporter:

![Imgur](http://i.imgur.com/mAcdT.png)

Note that the timing at the end is sadly completely erroneous, but could be fixed if the timing was done in the runner and not in the reporter.
