### PR TITLE
Don't complete until the response has come back from the webdriver quit

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,8 +131,9 @@ Cloud.prototype.start = function(fn){
 
               debug('results %j', res);
               self.emit('end', conf, res);
-              browser.quit();
-              done(null, res);
+              browser.quit(function(){
+                done(null, res);
+              });
             });
           }
 


### PR DESCRIPTION
I think this occasionally was cutting off the quit request and causing the instance to timeout instead of shutdown immediately. No idea really, though.
